### PR TITLE
Fix dynamic decoding bug on JS target

### DIFF
--- a/src/decode.gleam
+++ b/src/decode.gleam
@@ -523,7 +523,7 @@ pub const float: Decoder(Float) = Decoder(continuation: dynamic.float)
 /// // -> Ok(dynamic.from(3.14))
 /// ```
 ///
-pub const dynamic: Decoder(Dynamic) = Decoder(continuation: Ok)
+pub const dynamic: Decoder(Dynamic) = Decoder(continuation: dynamic.dynamic)
 
 /// A decoder that decodes `BitArray` values. This decoder never returns an error.
 ///


### PR DESCRIPTION
Hi!

When using `decode.dynamic` on JS target, `decode` crashes, because the generated code is wrong in the compiler.
It generates:

```js
export const dynamic = /* @__PURE__ */ new Decoder(/* @__PURE__ */ new Ok());
```

Which is not a function, as asked by `continuation`.
Using the `dynamic.dynamic` function fixes the bug. 🙂